### PR TITLE
Adds support for downloading arm64 binaries

### DIFF
--- a/get_tools.sh
+++ b/get_tools.sh
@@ -11,51 +11,80 @@ TERRAFORM_VERSION="${TERRAFORM_VERSION:-1.3.6}"
 TERRAGRUNT_VERSION="${TERRAGRUNT_VERSION:-0.42.5}"
 TF_SUMMARIZE_VERSION="${TF_SUMMARIZE_VERSION:-0.2.3}"
 
+CPU_ARCH=$(uname -m)
+
 cd "${RUNNER_TEMP}"
 
 # Get conftest
 
+if [[ "${OSTYPE}" == "darwin"* ]]; then
+  if [[ "${CPU_ARCH}" == "arm64" ]]; then
+    CONFTEST_OS="Darwin_arm64"
+    TERRAFORM_OS="darwin_arm64"
+    TERRAGRUNT_OS="darwin_arm64"
+    TF_SUMMARIZE_OS="darwin_arm64"
+  else
+    CONFTEST_OS="Darwin_x86_64"
+    TERRAFORM_OS="darwin_amd64"
+    TERRAGRUNT_OS="darwin_amd64"
+    TF_SUMMARIZE_OS="darwin_amd64"
+  fi
+else
+  if [[ "${CPU_ARCH}" == "aarch64" ]]; then
+    CONFTEST_OS="Linux_arm64"
+    TERRAFORM_OS="linux_arm64"
+    TERRAGRUNT_OS="linux_arm64"
+    TF_SUMMARIZE_OS="linux_arm64"
+  else
+    CONFTEST_OS="Linux_x86_64"
+    TERRAFORM_OS="linux_amd64"
+    TERRAGRUNT_OS="linux_amd64"
+    TF_SUMMARIZE_OS="linux_amd64"
+  fi
+fi
+
 echo "Getting conftest ${CONFTEST_VERSION} ..."
-wget "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz"
+wget "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/conftest_${CONFTEST_VERSION}_${CONFTEST_OS}.tar.gz"
 wget "https://github.com/open-policy-agent/conftest/releases/download/v${CONFTEST_VERSION}/checksums.txt"
-grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status
-tar -zxvf "conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" conftest
+grep "${CONFTEST_OS}.tar.gz" < checksums.txt | sha256sum --check  --status
+tar -zxvf "conftest_${CONFTEST_VERSION}_${CONFTEST_OS}.tar.gz" conftest
 chmod +x conftest
 mv conftest "${BIN_DIR}"
-rm "conftest_${CONFTEST_VERSION}_Linux_x86_64.tar.gz" checksums.txt
+rm "conftest_${CONFTEST_VERSION}_${CONFTEST_OS}.tar.gz" checksums.txt
 echo "Done downloading conftest ${CONFTEST_VERSION}"
 
 # Get terraform
 
 echo "Getting terraform ${TERRAFORM_VERSION} ..."
-wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip"
+wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TERRAFORM_OS}.zip"
 wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_SHA256SUMS"
-grep 'linux_amd64.zip' < "terraform_${TERRAFORM_VERSION}_SHA256SUMS" | sha256sum --check  --status
-unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" terraform
+grep "${TERRAFORM_OS}.zip" < "terraform_${TERRAFORM_VERSION}_SHA256SUMS" | sha256sum --check  --status
+unzip "terraform_${TERRAFORM_VERSION}_${TERRAFORM_OS}.zip" terraform
 chmod +x terraform
 mv terraform "${BIN_DIR}"
-rm "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" "terraform_${TERRAFORM_VERSION}_SHA256SUMS"
+rm "terraform_${TERRAFORM_VERSION}_${TERRAFORM_OS}.zip" "terraform_${TERRAFORM_VERSION}_SHA256SUMS"
 echo "Done downloading terraform ${TERRAFORM_VERSION}"
 
 # Get terragrunt
 
 echo "Getting terragrunt ${TERRAGRUNT_VERSION} ..."
-wget "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_linux_amd64"
+wget "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/terragrunt_${TERRAGRUNT_OS}"
 wget "https://github.com/gruntwork-io/terragrunt/releases/download/v${TERRAGRUNT_VERSION}/SHA256SUMS"
-grep 'linux_amd64' < SHA256SUMS | sha256sum --check  --status
-mv "terragrunt_linux_amd64" terragrunt
+grep "${TERRAGRUNT_OS}" < SHA256SUMS | sha256sum --check  --status
+mv "terragrunt_${TERRAGRUNT_OS}" terragrunt
 chmod +x terragrunt
 mv terragrunt "${BIN_DIR}"
 rm SHA256SUMS
 echo "Done downloading terragrunt ${TERRAGRUNT_VERSION}"
 
+# Get tf-summarize
 
 echo "Getting tf-summarize ${TF_SUMMARIZE_VERSION} ..."
-wget "https://github.com/dineshba/tf-summarize/releases/download/v${TF_SUMMARIZE_VERSION}/tf-summarize_linux_amd64.zip"
+wget "https://github.com/dineshba/tf-summarize/releases/download/v${TF_SUMMARIZE_VERSION}/tf-summarize_${TF_SUMMARIZE_OS}.zip"
 wget "https://github.com/dineshba/tf-summarize/releases/download/v${TF_SUMMARIZE_VERSION}/tf-summarize_SHA256SUMS"
-grep "tf-summarize_linux_amd64.zip" < tf-summarize_SHA256SUMS | sha256sum --check  --status
-unzip "tf-summarize_linux_amd64.zip" tf-summarize
+grep "tf-summarize_${TF_SUMMARIZE_OS}.zip" < tf-summarize_SHA256SUMS | sha256sum --check  --status
+unzip "tf-summarize_${TF_SUMMARIZE_OS}.zip" tf-summarize
 chmod +x tf-summarize
 mv tf-summarize "${BIN_DIR}"
-rm "tf-summarize_linux_amd64.zip" "tf-summarize_SHA256SUMS"
+rm "tf-summarize_${TF_SUMMARIZE_OS}.zip" "tf-summarize_SHA256SUMS"
 echo "Done downloading tf-summarize ${TF_SUMMARIZE_VERSION}"

--- a/test_script.sh
+++ b/test_script.sh
@@ -34,8 +34,7 @@ mkdir ${TEST_DIR}
 BIN_DIR=${TEST_DIR} RUNNER_TEMP=${RUNNER_TEMP} ./get_tools.sh
 
 test "conftest" "$(${TEST_DIR}/conftest --version | head -n 1)" "Conftest: ${CONFTEST_VERSION}"
-test "terraform" "$(${TEST_DIR}/terraform --version)" "Terraform v${TERRAFORM_VERSION}
-on linux_amd64"
+test "terraform" "$(${TEST_DIR}/terraform --version | head -n 1)" "Terraform v${TERRAFORM_VERSION}"
 test "terragrunt" "$(${TEST_DIR}/terragrunt --version)" "terragrunt version v${TERRAGRUNT_VERSION}"
 test "tf-summarize" "$(${TEST_DIR}/tf-summarize -v)" "Version: ${TF_SUMMARIZE_VERSION}"
 


### PR DESCRIPTION
# Summary | Résumé

This PR updates the shell script to add automatic support for macOS operating systems and ARM64 architectures. It also makes a minor adjustment to the test suite so that it will pass regardless of the version of terraform is running, which incidentally resolves #8.

# Test instructions | Instructions pour tester la modification

This PR can be tested on the new operating systems and architectures fairly easily when running on a Mac running on arm64. The only necessary command to run is the `test_script.sh` script.

In order to test on a Linux operating system, I used Docker and included the following files:

### Dockerfile

```dockerfile
FROM ubuntu

RUN apt update && apt install -y wget unzip

WORKDIR /app
COPY . /app
RUN ./test_script.sh
```

### .dockerignore

```
Dockerfile
test_dir
```

Then ran the following steps to build / test:

```bash
docker build --tag terraform-tools-setup .
docker build --platform=linux/amd64 --tag terraform-tools-setup .
```

Alternately the source code could be mounted into a virtual machine or physical hardware with the appropriate CPU architecture and Operating Systems.
